### PR TITLE
Fix the dotnet implementation in the redirect samples

### DIFF
--- a/modal/server/dotnet/server.csproj
+++ b/modal/server/dotnet/server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
 
@@ -12,7 +12,7 @@
     <Folder Include="Models\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[3.1,]" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="DotNetEnv" Version="2.2.0" />
     <PackageReference Include="Stripe.net" Version="39.83.0" />

--- a/redirect/server/dotnet/Controllers/IdentityController.cs
+++ b/redirect/server/dotnet/Controllers/IdentityController.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Stripe;
-using Stripe.Checkout;
+using Stripe.Identity;
 
 namespace server.Controllers
 {
@@ -43,11 +43,8 @@ namespace server.Controllers
           try
           {
             var verificationSession = await service.CreateAsync(options);
-
-            return Ok(new CreateVerificationSessionResponse
-            {
-                ClientSecret = verificationSession.ClientSecret,
-            });
+            Response.Headers["Location"] = verificationSession.Url;
+            return StatusCode(303);
           }
           catch (StripeException e)
           {

--- a/redirect/server/dotnet/Models/CreatePaymentIntentResponse.cs
+++ b/redirect/server/dotnet/Models/CreatePaymentIntentResponse.cs
@@ -1,8 +1,8 @@
 using Newtonsoft.Json;
 
-public class CreatePaymentIntentResponse
+public class CreateVerificationSessionResponse
 {
-  [JsonProperty("clientSecret")]
+  [JsonProperty("client_secret")]
   public string ClientSecret { get; set; }
 }
 

--- a/redirect/server/dotnet/server.csproj
+++ b/redirect/server/dotnet/server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
 
@@ -12,7 +12,7 @@
     <Folder Include="Models\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[3.1,]" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="DotNetEnv" Version="2.2.0" />
     <PackageReference Include="Stripe.net" Version="39.83.0" />


### PR DESCRIPTION
Hello. I fixed failing CI jobs with the following changes:

* Add .Net 5.0 support.
* Fix missing namespaces.
* Fix missing JSON properties.
* Make `POST /create-verification-session` respond with 303 as the other implementations.

The latest CI result on my fork: https://github.com/hibariya/identity/actions/runs/1633457070