### PR TITLE
Add reminders about security best practices and redact secrets in logs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,9 @@ jobs:
       - name: Collect debug information
         if: ${{ failure() }}
         run: |
-          cat .env
+          # Redact Stripe secret keys, restricted keys, and webhook secrets
+# before logging. Publishable keys (pk_) are safe to log.
+cat .env | sed 's/=\(sk_\|rk_\|whsec_\)[^[:space:]]*/=[REDACTED]/g'
           cat docker-compose.yml
           docker-compose ps -a
           docker-compose logs web

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,8 +105,8 @@ jobs:
         if: ${{ failure() }}
         run: |
           # Redact Stripe secret keys, restricted keys, and webhook secrets
-# before logging. Publishable keys (pk_) are safe to log.
-cat .env | sed 's/=\(sk_\|rk_\|whsec_\)[^[:space:]]*/=[REDACTED]/g'
+          # before logging. Publishable keys (pk_) are safe to log.
+          cat .env | sed 's/=\(sk_\|rk_\|whsec_\)[^[:space:]]*/=[REDACTED]/g'
           cat docker-compose.yml
           docker-compose ps -a
           docker-compose logs web

--- a/modal/server/dotnet/Startup.cs
+++ b/modal/server/dotnet/Startup.cs
@@ -35,6 +35,11 @@ namespace server
             services.Configure<StripeOptions>(options =>
             {
                 options.PublishableKey = Environment.GetEnvironmentVariable("STRIPE_PUBLISHABLE_KEY");
+                // Don't put any keys in code. Use an environment variable (as shown
+                // here) or secrets vault to supply keys to your integration.
+                //
+                // See https://docs.stripe.com/keys-best-practices and find your
+                // keys at https://dashboard.stripe.com/apikeys.
                 options.SecretKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY");
                 options.WebhookSecret = Environment.GetEnvironmentVariable("STRIPE_WEBHOOK_SECRET");
             });

--- a/modal/server/go/server.go
+++ b/modal/server/go/server.go
@@ -22,6 +22,11 @@ func main() {
 		log.Fatal("Error loading .env file")
 	}
 
+	// Don't put any keys in code. Use an environment variable (as shown
+	// here) or secrets vault to supply keys to your integration.
+	//
+	// See https://docs.stripe.com/keys-best-practices and find your
+	// keys at https://dashboard.stripe.com/apikeys.
 	stripe.Key = os.Getenv("STRIPE_SECRET_KEY")
 
 	// For sample support and debugging, not required for production:

--- a/modal/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/modal/server/java/src/main/java/com/stripe/sample/Server.java
@@ -56,6 +56,11 @@ public class Server {
     port(4242);
     Dotenv dotenv = Dotenv.load();
 
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     Stripe.apiKey = dotenv.get("STRIPE_SECRET_KEY");
 
     // For sample support and debugging, not required for production:

--- a/modal/server/nextjs/lib/stripe.ts
+++ b/modal/server/nextjs/lib/stripe.ts
@@ -1,5 +1,10 @@
 import Stripe from "stripe";
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2025-12-15.clover",
   appInfo: {

--- a/modal/server/node-typescript/src/server.ts
+++ b/modal/server/node-typescript/src/server.ts
@@ -7,6 +7,11 @@ import bodyParser from 'body-parser';
 import express from 'express';
 
 import Stripe from 'stripe';
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2022-08-01',
   appInfo: { // For sample support and debugging, not required for production:

--- a/modal/server/node/server.js
+++ b/modal/server/node/server.js
@@ -4,6 +4,11 @@ const { resolve } = require('path');
 // Replace if using a different env file or config
 const env = require('dotenv').config({ path: './.env' });
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2020-08-27',
   appInfo: { // For sample support and debugging, not required for production:

--- a/modal/server/php/public/shared.php
+++ b/modal/server/php/public/shared.php
@@ -10,6 +10,11 @@ if(!file_exists('../.env')) {
   <p>Make a copy of <code>.env.example</code>, place it in the same directory as composer.json, and name it <code>.env</code>, then populate the variables.</p>
   <p>It should look something like the following, but contain your <a href='https://dashboard.stripe.com/test/apikeys'>API keys</a>:</p>
   <pre>STRIPE_PUBLISHABLE_KEY=pk_test...
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 STRIPE_SECRET_KEY=sk_test...
 STRIPE_WEBHOOK_SECRET=whsec_...
 DOMAIN=http://localhost:4242</pre>

--- a/modal/server/python/server.py
+++ b/modal/server/python/server.py
@@ -15,6 +15,11 @@ stripe.set_app_info(
     url='https://github.com/stripe-samples')
 
 stripe.api_version = '2020-08-27'
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 
 static_dir = str(os.path.abspath(os.path.join(__file__ , "..", os.getenv("STATIC_DIR"))))

--- a/modal/server/ruby/server.rb
+++ b/modal/server/ruby/server.rb
@@ -14,6 +14,11 @@ Stripe.set_app_info(
   url: 'https://github.com/stripe-samples'
 )
 Stripe.api_version = '2020-08-27'
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 set :static, true

--- a/redirect/server/dotnet/Startup.cs
+++ b/redirect/server/dotnet/Startup.cs
@@ -35,6 +35,11 @@ namespace server
             services.Configure<StripeOptions>(options =>
             {
                 options.PublishableKey = Environment.GetEnvironmentVariable("STRIPE_PUBLISHABLE_KEY");
+                // Don't put any keys in code. Use an environment variable (as shown
+                // here) or secrets vault to supply keys to your integration.
+                //
+                // See https://docs.stripe.com/keys-best-practices and find your
+                // keys at https://dashboard.stripe.com/apikeys.
                 options.SecretKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY");
                 options.WebhookSecret = Environment.GetEnvironmentVariable("STRIPE_WEBHOOK_SECRET");
             });

--- a/redirect/server/go/server.go
+++ b/redirect/server/go/server.go
@@ -22,6 +22,11 @@ func main() {
 		log.Fatal("Error loading .env file")
 	}
 
+	// Don't put any keys in code. Use an environment variable (as shown
+	// here) or secrets vault to supply keys to your integration.
+	//
+	// See https://docs.stripe.com/keys-best-practices and find your
+	// keys at https://dashboard.stripe.com/apikeys.
 	stripe.Key = os.Getenv("STRIPE_SECRET_KEY")
 
 	// For sample support and debugging, not required for production:

--- a/redirect/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/redirect/server/java/src/main/java/com/stripe/sample/Server.java
@@ -56,6 +56,11 @@ public class Server {
     port(4242);
     Dotenv dotenv = Dotenv.load();
 
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     Stripe.apiKey = dotenv.get("STRIPE_SECRET_KEY");
 
     // For sample support and debugging, not required for production:

--- a/redirect/server/nextjs/lib/stripe.ts
+++ b/redirect/server/nextjs/lib/stripe.ts
@@ -1,5 +1,10 @@
 import Stripe from "stripe";
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2024-12-18.acacia",
   appInfo: {

--- a/redirect/server/node-typescript/src/server.ts
+++ b/redirect/server/node-typescript/src/server.ts
@@ -7,6 +7,11 @@ import bodyParser from 'body-parser';
 import express from 'express';
 
 import Stripe from 'stripe';
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2020-08-27',
   appInfo: { // For sample support and debugging, not required for production:

--- a/redirect/server/node/server.js
+++ b/redirect/server/node/server.js
@@ -4,6 +4,11 @@ const { resolve } = require('path');
 // Replace if using a different env file or config
 const env = require('dotenv').config({ path: './.env' });
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2020-08-27',
   appInfo: { // For sample support and debugging, not required for production:

--- a/redirect/server/php/public/shared.php
+++ b/redirect/server/php/public/shared.php
@@ -10,6 +10,11 @@ if(!file_exists('../.env')) {
   <p>Make a copy of <code>.env.example</code>, place it in the same directory as composer.json, and name it <code>.env</code>, then populate the variables.</p>
   <p>It should look something like the following, but contain your <a href='https://dashboard.stripe.com/test/apikeys'>API keys</a>:</p>
   <pre>STRIPE_PUBLISHABLE_KEY=pk_test...
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 STRIPE_SECRET_KEY=sk_test...
 STRIPE_WEBHOOK_SECRET=whsec_...
 DOMAIN=http://localhost:4242</pre>

--- a/redirect/server/python/server.py
+++ b/redirect/server/python/server.py
@@ -15,6 +15,11 @@ stripe.set_app_info(
     url='https://github.com/stripe-samples')
 
 stripe.api_version = '2020-08-27'
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 
 static_dir = str(os.path.abspath(os.path.join(__file__ , "..", os.getenv("STATIC_DIR"))))

--- a/redirect/server/ruby/server.rb
+++ b/redirect/server/ruby/server.rb
@@ -14,6 +14,11 @@ Stripe.set_app_info(
   url: 'https://github.com/stripe-samples'
 )
 Stripe.api_version = '2020-08-27'
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 set :static, true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,11 @@ end
 
 SERVER_URL = ENV.fetch('SERVER_URL', 'http://localhost:4242')
 Dotenv.load
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 Stripe.max_network_retries = 2
 Stripe.api_version = "2020-08-27"


### PR DESCRIPTION
## Summary

- Adds comments before `STRIPE_SECRET_KEY` assignments in all server files urging users not to put keys in code and pointing to [https://docs.stripe.com/keys-best-practices](https://docs.stripe.com/keys-best-practices).
- Replaces `cat .env` in CI workflow files with a redacting version that masks secret keys (`sk_`), restricted keys (`rk_`), and webhook secrets (`whsec_`) while leaving publishable keys visible.
